### PR TITLE
Add missing attribute

### DIFF
--- a/book_src/ex1.md
+++ b/book_src/ex1.md
@@ -586,6 +586,7 @@ So when we put it all together we get this:
 
 #[naked]
 #[no_mangle]
+#[instruction_set(arm::a32)]
 #[link_section = ".text._start"]
 unsafe extern "C" fn _start() -> ! {
   core::arch::asm! {


### PR DESCRIPTION
This attribute was missing on the second version, I ended up copying this part directly and got really confused why mgba was rejecting it, turns out I missed this line and it ended up generating thumb code, oops.

And huge thanks for writing this, I wanted to get a bare minimum gba game building in rust but I wanted to really understand what's going on with that assembly and linker magic, this satisfied my curiosity, looking forward for more.